### PR TITLE
Update react-server-dom-* and React packages to secure versions (CVE-2025-55182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "fumadocs-mdx": "11.5.7",
     "fumadocs-ui": "15.2.2",
     "lucide-react": "^0.487.0",
-    "next": "15.2.4",
+    "next": "15.2.6",
     "next-themes": "^0.4.6",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "19.1.2",
+    "react-dom": "19.1.2",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5"
   },


### PR DESCRIPTION
This PR automatically bumps react-server-dom-* and related react dependencies (react, react-dom) to secure versions in order to mitigate CVE-2025-55182 and related vulnerabilities.

For details on the security issue and upstream changes, see: https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components.

If you have customized these dependencies, please review the changes and test accordingly.